### PR TITLE
Address CVE-2024-39689

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ azure-core==1.29.4
 azure-storage-blob==12.18.3
 boto3==1.28.63
 botocore==1.31.63
-certifi==2022.12.7
+certifi==2024.7.4
 cffi==1.16.0
 chardet==5.2.0
 cryptography==41.0.4


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/cve-2024-39689
https://github.com/certifi/python-certifi/security/advisories/GHSA-248v-346w-9cwc

Address CVE-2024-39689, GHSA-248v-346w-9cwc
bump certifi to 2024.7.4