### PR TITLE
AN-19495: Replace deprecated ::set-output

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -5,7 +5,7 @@ from typing import List
 from snowflake_connector import QueryResult
 
 def set_github_action_output(var_name, value):
-    os.system(f'echo "::set-output name={var_name}::"{value}""')
+    os.system(f'echo "{var_name}={value}" >> $GITHUB_OUTPUT')
 
 async def gather_all_results(query_result_list: List[QueryResult]) -> dict:
     """
@@ -18,7 +18,7 @@ async def gather_all_results(query_result_list: List[QueryResult]) -> dict:
 
     Returns:
         str: json contains all of the results.
-    """    
+    """
     running_tasks = {asyncio.create_task(query_result.fetch_results(), name=query_result.query_id)
                                      for query_result in query_result_list}
 

--- a/utils.py
+++ b/utils.py
@@ -1,11 +1,14 @@
-import os
 import asyncio
+from os import environ
 from typing import List
 
 from snowflake_connector import QueryResult
 
+
 def set_github_action_output(var_name, value):
-    os.system(f'echo "{var_name}={value}" >> $GITHUB_OUTPUT')
+    with open(environ['GITHUB_OUTPUT'], 'a') as f:
+        f.write(f"{var_name}={value}\n")
+
 
 async def gather_all_results(query_result_list: List[QueryResult]) -> dict:
     """


### PR DESCRIPTION
This PR updates GitHub Actions usage to remove deprecated ::set-output syntax.
Closes #12 
Closes #16 